### PR TITLE
Updated unusable hadoop distribution url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /opt
 WORKDIR /opt
 
 # Install Hadoop
-RUN curl -L http://apache.crihan.fr/dist/hadoop/common/hadoop-2.7.2/hadoop-2.7.2.tar.gz -s -o - | tar -xzf -
+RUN curl -L https://archive.apache.org/dist/hadoop/core/hadoop-2.7.2/hadoop-2.7.2.tar.gz -s -o - | tar -xzf -
 RUN mv hadoop-2.7.2 hadoop
 
 # Setup


### PR DESCRIPTION
Hadoop installation no longer usable. 

Could even upgrade the version of hadoop too 